### PR TITLE
Fallback to pool.ntp.org if NTP isn't configured

### DIFF
--- a/docker-time-sync-agent/update-docker-time
+++ b/docker-time-sync-agent/update-docker-time
@@ -6,4 +6,4 @@
 #  Created by ArunvelSriram on 26/12/16.
 #  Copyright © 2016 ArunvelSriram. All rights reserved.
 
-/usr/local/bin/docker run --rm --privileged --pid=host walkerlee/nsenter -t 1 -m -u -i -n ntpd -d -q -n -p `cat /etc/ntp.conf | awk '{ print $2 }'`
+/usr/local/bin/docker run --rm --privileged --pid=host walkerlee/nsenter -t 1 -m -u -i -n ntpd -d -q -n -p `if [[ -f /etc/ntp.conf ]]; then cat /etc/ntp.conf | awk '{ print $2 }'; else echo 'pool.ntp.org'; fi`


### PR DESCRIPTION
On my setup there was no /etc/ntp.conf:

```
❯ docker run --rm --privileged --pid=host walkerlee/nsenter -t 1 -m -u -i -n cat /etc/ntp.conf
cat: can't open '/etc/ntp.conf': No such file or directory
```

…so #1 broke time syncing. This PR add pool.ntp.org back, but as a fallback.